### PR TITLE
Pass authuser back to caller

### DIFF
--- a/nginx/auth.php
+++ b/nginx/auth.php
@@ -84,6 +84,10 @@ session_start();
 //====================================================
 // Check if the authentication has been completed
 if (isset($_SESSION["authenticated"]) && $_SESSION["authenticated"] === true) {
+        // pass authenticated username back up the stack to nginx - so it can
+	// be passed on to the protected application.
+	$userheader = "X-Auth-User: " . $_SESSION["username"];
+	header($userheader);
 	http_response_code(200);
 }
 else {


### PR DESCRIPTION
Passes the authenticated username back to nginx.
Useful to enable passing of authenticated user to the protected application / proxied web site.

Example nginx conf to utilise this:
```
# # For local php (or other pages served from nginx) - authentication passing username in "HTTP_X_AUTH_USER"
# # ( with php, see $_SERVER['HTTP_X_AUTH_USER']  )
#   location / {
#     auth_request /twofactorauth/nginx/auth.php;
#     auth_request_set $auth_user $upstream_http_x_auth_user;
# 
#     index index.html index.htm index.nginx-debian.html index.php;
# 
#     location ~ [^/]\.php(/|$) {
#       auth_request /twofactorauth/nginx/auth.php;
#       auth_request_set $auth_user $upstream_http_x_auth_user;
#       proxy_set_header X-Auth-User $auth_user;
# 
#       fastcgi_split_path_info ^(.+?\.php)(/.*)$;
#       if (!-f $document_root$fastcgi_script_name) {
#         return 404;
#       }
#       # Mitigate https://httpoxy.org/ vulnerabilities
#       fastcgi_param HTTP_PROXY "";
# 
#       # passthrough user authenticated name
#       fastcgi_param HTTP_X_AUTH_USER $auth_user;
# 
#       fastcgi_pass unix:/run/php/php8.1-fpm.sock;
#       include /etc/nginx/fastcgi.conf;
#     }
#   }
 
 
# for remote web server, authentication passing in header "X-Auth-User" (which appears in apache environment as HTTP_X_AUTH_USER)
# Note - this is confusing as nginx renames response headers into variables automatically ... the mapping
#        is not obvious.
# 1. auth.php checks for authenticated session (php) - and emits the username as a new header X-Auth-User
#    this is identified in the auth_request_set statement as "$upstream_http_x_auth_user", which the config
#    maps to the new NGINX variable $auth user.
 
location / {
# Order is not important, I have ordered these to make it a bit clearer only.
# 
# first - every page request results in an internal sub-request to auth.php
# responds with 200 for "authorised" - anything else == unauthorised.
	auth_request /twofactorauth/nginx/auth.php;
 
# After successful auth request, 
# capture any "X-Auth-User: name" value in nginx variable $auth_user 
# (note, nginx has mapped response header X-Auth-User to $upstream_http_x_auth_user - 
#  upstream is the authenticator request server)
	auth_request_set $auth_user $upstream_http_x_auth_user;
 
# Add to the real request headers a new header "X-Auth-User" capturing the actual
# authenticated user name
	proxy_set_header X-Auth-User $auth_user;
 
# add some other context headers (not essential, but sometimes useful)
	proxy_set_header X-Original-URI $request_uri;
	proxy_set_header X-Original-Remote-Addr $remote_addr;
	proxy_set_header X-Original-Host $host;
 
# then forward off to the real web server
	proxy_pass       http://127.0.0.1:8080;
 
# only necessary if streaming / progress indicators used. Slows things down though.
	#proxy_buffering off;
}
 
}
```